### PR TITLE
remove extra syntax highlighting option

### DIFF
--- a/roles/nvim/templates/init.vim.j2
+++ b/roles/nvim/templates/init.vim.j2
@@ -3,8 +3,6 @@ call plug#begin("~/.vim/plugged")
  Plug 'jeffkreeftmeijer/vim-dim'
 call plug#end()
 
- syntax enable
-
 " colorscheme choice
 colorscheme dim
 


### PR DESCRIPTION
* syntax on is the same as syntax enable (which is the nvim option)